### PR TITLE
Refactor to use librpm and fallback to cmd

### DIFF
--- a/JsonStats/FetchStats/Plugins/RPM.py
+++ b/JsonStats/FetchStats/Plugins/RPM.py
@@ -1,8 +1,12 @@
 import datetime
 from JsonStats.FetchStats import Fetcher
-
+try:
+    import rpm
+except:
+    pass
 
 class RPM(Fetcher):
+    
     def __init__(self):
         """
         Returns an rpm manifest (all rpms installed on the system.
@@ -14,6 +18,29 @@ class RPM(Fetcher):
 
     def _load_data(self):
         self._refresh_time = datetime.datetime.utcnow()
+
+        try:
+            if 'rpm' in globals():
+                print "lib"
+                self._get_rpms_with_lib()
+            else:
+                self._get_rpms_with_cmd()
+            self._loaded(True)
+        except Exception, e:
+            self._loaded(False, str(e))
+
+    def _get_rpms_with_lib(self):
+        self._rpms = {}
+        transaction_set = rpm.TransactionSet()
+        mi = transaction_set.dbMatch()
+        try:
+            for header in mi:
+                self._rpms[header['name']] = header['version']
+        except Exception, e:
+            raise
+
+
+    def _get_rpms_with_cmd(self):
         self._rpms = {}
 
         cmd = 'rpm -qa --queryformat "%{NAME} %{VERSION}\n"'
@@ -22,9 +49,9 @@ class RPM(Fetcher):
             for line in self._exec(cmd).split('\n')[:-1]:
                 (rpm_name, rpm_version) = line.split()
                 self._rpms[rpm_name] = rpm_version
-            self._loaded(True)
         except Exception, e:
-            self._loaded(False, str(e))
+            raise
+        
 
     def dump(self):
         # poor mans cache, refresh cache in an hour


### PR DESCRIPTION
This is a take on issue #27. We try to load the rpm package, and we check for it's existence in the global space when determining if we want to use lib rpm or fallback to calling the command.
