### PR TITLE
Use a more standard RPM query format

### DIFF
--- a/JsonStats/FetchStats/Plugins/RPM.py
+++ b/JsonStats/FetchStats/Plugins/RPM.py
@@ -16,7 +16,7 @@ class RPM(Fetcher):
         self._refresh_time = datetime.datetime.utcnow()
         self._rpms = {}
 
-        cmd = 'rpm -qa --queryformat "%{NAME} %{VERSION}\n"'
+        cmd = 'rpm -qa --queryformat "%{NAME} %{VERSION}-%{RELEASE}.%{ARCH}\n"'
 
         try:
             for line in self._exec(cmd).split('\n')[:-1]:


### PR DESCRIPTION
%{VERSION}-%{RELEASE}.%{ARCH}\n

ie: kernel 3.15.3-200.fc20.x86_64

Fixes: issue33
