### PR TITLE
Disable Facter plugin if yaml import fails

### DIFF
--- a/JsonStats/FetchStats/Plugins/Facter.py
+++ b/JsonStats/FetchStats/Plugins/Facter.py
@@ -17,16 +17,24 @@ class Facter(Fetcher):
 
     Dependencies:
     * Facter - http://puppetlabs.com/blog/facter-part-1-facter-101
+    * PyYAML - http://pyyaml.org/wiki/PyYAML
 
     Optional dependencies:
     * Puppet - http://puppetlabs.com/puppet/what-is-puppet
     """
 
-    import yaml
+    try:
+        import yaml
+    except ImportError:
+        yaml = None
 
     def __init__(self):
         self.context = 'facter'
         self._cmd = 'facter --yaml 2>/dev/null'
+
+        if self.yaml is None:
+            self._loaded(False, msg='No module named yaml')
+            return
 
         if os.path.exists('/usr/bin/puppet'):
             self._cmd = 'facter -p --yaml 2>/dev/null'


### PR DESCRIPTION
Currently if the yaml module is not installed startup of jsonstatsd will fail.
This commit wraps the import of yaml with a try/except block that allows the
constructor to detect the failure and disable the plugin rather than
propagating the ImportError exception.
